### PR TITLE
feat: support for allowing requests without Origin set

### DIFF
--- a/router.go
+++ b/router.go
@@ -85,10 +85,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	originURL, err := r.parseOrigin(request.Header.Get("Origin"))
-	if err != nil {
-		r.blockRequestf(w, "invalid origin: %s", err)
-		return
+	var originHost string
+	if r.Origins[0] != "*" { // do not validate origins when Origins: ["*"]
+		originURL, err := r.parseOrigin(request.Header.Get("Origin"))
+		if err != nil {
+			r.blockRequestf(w, "invalid origin: %s", err)
+			return
+		}
+		originHost = originURL.Host
 	}
 
 	targetURL, err := r.parseTarget(request.URL)
@@ -102,7 +106,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	r.logf("redirecting %s -> %s", originURL.Host, targetURL.Host)
+	r.logf("redirecting %s -> %s", originHost, targetURL.Host)
 
 	http.Redirect(w, request, targetURL.String(), http.StatusFound)
 }

--- a/router_test.go
+++ b/router_test.go
@@ -110,6 +110,23 @@ func TestRouter_ServeHTTP(t *testing.T) {
 	})
 }
 
+func TestRouter_EmptyOriginRequests(t *testing.T) {
+	t.Parallel()
+
+	origin, target := "", "http://example.com"
+
+	router := oar.Router{
+		Targets: []string{"example.com"},
+		Origins: []string{"*"},
+	}
+
+	w := httptest.NewRecorder()
+	r := request(origin, makeState(target))
+	router.ServeHTTP(w, r)
+	expectStatus(t, w, http.StatusFound)
+	expectBody(t, w, target)
+}
+
 func TestRouter_URLMatching(t *testing.T) {
 	t.Parallel()
 
@@ -282,7 +299,9 @@ func request(origin, state string) *http.Request {
 	u.RawQuery = q.Encode()
 
 	r := httptest.NewRequest(http.MethodGet, u.String(), nil)
-	r.Header.Set("Origin", origin)
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
 
 	return r
 }


### PR DESCRIPTION
This PR adds support for allowing requests with no Origin headers set. One example when this happens is Dropbox OAuth2.